### PR TITLE
[CORE-000] Add new cops introduced in version 0.80 and 0.81

### DIFF
--- a/edgecop-core.yml
+++ b/edgecop-core.yml
@@ -54,3 +54,9 @@ Style/HashTransformKeys:
 
 Style/HashTransformValues:
   Enabled: true
+
+Lint/RaiseException:
+  Enabled: true
+
+Lint/StructNewOverride:
+  Enabled: true


### PR DESCRIPTION
We needed new cops enabled for version 0.8 and 0.81. Rubocop wouldn't run otherwise.
I can't think of any good reason why we wouldn't enable these cops.

https://docs.rubocop.org/en/latest/cops_lint/#lintraiseexception
https://docs.rubocop.org/en/latest/cops_lint/#lintstructnewoverride

Have tested locally, this solves the issue.