### PR TITLE
[EDGE-000] Disable check for `MissingSuper`

### DIFF
--- a/edgecop-core.yml
+++ b/edgecop-core.yml
@@ -73,3 +73,6 @@ Lint/RaiseException:
 
 Lint/StructNewOverride:
   Enabled: true
+
+Lint/MissingSuper:
+  Enabled: false


### PR DESCRIPTION
Rubocop often complains about missing `super`:
![image](https://user-images.githubusercontent.com/53298534/125958289-63eaf506-4e33-4cdc-b03f-61f2796ab01f.png)
In some cases that is a valid complaint but much more often than not it doesn't apply to code we write.

This PR disables that check.

