### PR TITLE
[SS-962] Add exclusions for some Rubocop Rspec related rules

### DIFF
--- a/edgecop-rspec.yml
+++ b/edgecop-rspec.yml
@@ -1,3 +1,15 @@
+require: rubocop-rspec
+
+RSpec/ContextWording:
+  Prefixes:
+    - when
+    - with
+    - without
+    - where
+    - if
+    - unless
+    - for
+
 RSpec/NestedGroups:
   Enabled: false
 

--- a/edgecop-rspec.yml
+++ b/edgecop-rspec.yml
@@ -21,3 +21,9 @@ RSpec/MultipleExpectations:
 
 RSpec/LetSetup:
   Enabled: false
+
+RSpec/ExampleLength:
+  Max: 8
+
+RSpec/Rails/HttpStatus:
+  EnforcedStyle: numeric

--- a/edgecop-rspec.yml
+++ b/edgecop-rspec.yml
@@ -1,0 +1,11 @@
+RSpec/NestedGroups:
+  Enabled: false
+
+RSpec/MultipleMemoizedHelpers:
+  Enabled: false
+
+RSpec/MultipleExpectations:
+  Enabled: false
+
+RSpec/LetSetup:
+  Enabled: false

--- a/edgecop.yml
+++ b/edgecop.yml
@@ -1,4 +1,5 @@
-inherit_from: 
+inherit_from:
   - https://raw.githubusercontent.com/BCCRiskAdvisory/edgecop/main/edgecop-core.yml
   - https://raw.githubusercontent.com/BCCRiskAdvisory/edgecop/main/edgecop-performance.yml
   - https://raw.githubusercontent.com/BCCRiskAdvisory/edgecop/main/edgecop-rails.yml
+  - https://raw.githubusercontent.com/BCCRiskAdvisory/edgecop/main/edgecop-rspec.yml


### PR DESCRIPTION
Jira issue: [\[SS-962\] Make Rubocop failures block merges into EdgeRails' develop](https://edgescan.atlassian.net/browse/SS-962)
Related EdgeRails PR: https://github.com/BCCRiskAdvisory/EdgeRails/pull/2402

## Changes
- Added exclusions for some Rubocop Rspec related rules