### PR TITLE
[CD-1271] Added "on" prefix to allowed rspec prefixes

### DIFF
--- a/edgecop-rspec.yml
+++ b/edgecop-rspec.yml
@@ -9,6 +9,7 @@ RSpec/ContextWording:
     - if
     - unless
     - for
+    - on
 
 RSpec/NestedGroups:
   Enabled: false


### PR DESCRIPTION
Linked PRs: (if any)
[edgescan-core CD-1271](https://github.com/BCCRiskAdvisory/edgescan-core/pull/182)

## Ops Summary
Allowing rspec contexts to begin with "on".

I have a [PR](https://github.com/BCCRiskAdvisory/edgescan-core/pull/182) with the following rspec test:
![Screenshot from 2023-10-10 16-23-59](https://github.com/BCCRiskAdvisory/edgecop/assets/9440166/08b4f30f-7d82-4896-b0fb-8c6e84344b53)

I think "on" is a reasonable prefix to add to our `rubocop.yml`

