### PR TITLE
Update rubocop rule to favour keyword args over positional args 

### DIFF
--- a/edgecop-core.yml
+++ b/edgecop-core.yml
@@ -28,6 +28,10 @@ Metrics/BlockLength:
     - "Gemfile"
     - "spec/**/*"
 
+Metrics/ParameterLists:
+  Max: 3
+  CountKeywordArgs: false
+
 Style/ExponentialNotation:
   Enabled: false
 


### PR DESCRIPTION
Documentation: (if any)
- [Teams chat in Clean Code Chapter](https://teams.microsoft.com/l/message/19:320e455af1f6458e81a040bfc6fe2df1@thread.skype/1702296211997?tenantId=b503d5f8-66cb-4c4d-8a56-053fbd4b0ebe&groupId=32a06cda-ba10-4ff5-939a-0077651b9014&parentMessageId=1702296211997&teamName=dev&channelName=Clean%20Code%20Chapter&createdTime=1702296211997)

## Ops Summary
- INTERNAL TECH DEBT | Update rubocop rule to favour keyword args over positional args 

## The Problem
- The idea is that keyword args should be preferred and we don't necessarily want to limit the number of these as they're more descriptive and preferred over passing in collection objects. However, we do want to limit the number of positional arguments.

## Changes
- Reduced the max number of arguments down to 3
- Excluded keyword arguments from the max count

## Deployment Impacts
- Rubocop rule will only fail on PRs where there is a change here that adds new violation or makes it worse. In this case devs either decide whether they are happy to do the refactor now and fix or else ask TL to force-merge and we take it on as tech debt later. (TL can push back and request fix if they don't agree)

## Security Impacts
None
